### PR TITLE
close-s3-connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+rest-s3-proxy

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module rest-s3-proxy
+
+require github.com/aws/aws-sdk-go v1.19.9

--- a/proxy.go
+++ b/proxy.go
@@ -161,6 +161,7 @@ func serveHealth(w http.ResponseWriter, r *http.Request) {
 func serveGetS3File(filePath string, w http.ResponseWriter, r *http.Request) {
 	params := &s3.GetObjectInput{Bucket: aws.String(awsBucket), Key: aws.String(filePath)}
 	resp, err := s3Session.GetObject(params)
+  defer resp.Body.Close()
 
 	if handleHTTPException(filePath, w, err) != nil {
 		return

--- a/proxy.go
+++ b/proxy.go
@@ -161,7 +161,7 @@ func serveHealth(w http.ResponseWriter, r *http.Request) {
 func serveGetS3File(filePath string, w http.ResponseWriter, r *http.Request) {
 	params := &s3.GetObjectInput{Bucket: aws.String(awsBucket), Key: aws.String(filePath)}
 	resp, err := s3Session.GetObject(params)
-  defer resp.Body.Close()
+	defer resp.Body.Close()
 
 	if handleHTTPException(filePath, w, err) != nil {
 		return


### PR DESCRIPTION
If the client terminates the connection early, the connection to S3 also does not appear to get cleaned up automatically. This can be seen by an increasing socket/file-descriptor count associated with this process if you run something like:
`while true; do timeout 0.1s curl localhost:<port-of-proxy>/path/to/big/file; done`
And checking the fd count using `sudo ls /proc/<proxy-pid>/fd | wc -l` or `lsof -Pnp <proxy-pid>`

Also added a file to make first time builds easier when having just checked out the repository. 